### PR TITLE
fix: vtm_traffic_manager.appliance_name_servers

### DIFF
--- a/8.3/build.sh
+++ b/8.3/build.sh
@@ -21,13 +21,13 @@ binBase="../bin"
 for platform in $platforms; do
     binDir="${binBase}/${platform}-${GOARCH}"
     mkdir -p ${binDir}
-    echo "Building v8.3.1 for ${platform}.."
+    echo "Building v8.3.2 for ${platform}.."
     if [[ "${platform}" == "windows" ]]; then
         ext=".exe"
     else
         ext=""
     fi
-    TARGET=${binDir}/terraform-provider-vtm_v8.3.1${ext}
+    TARGET=${binDir}/terraform-provider-vtm_v8.3.2${ext}
     CGO_ENABLED=0 GOOS=$platform go build -mod=vendor -o ${TARGET} \
         -a -ldflags '-extldflags "-static -s"' .
 done

--- a/8.3/resource_traffic_manager.go
+++ b/8.3/resource_traffic_manager.go
@@ -534,7 +534,7 @@ func getResourceTrafficManagerSchema() map[string]*schema.Schema {
 		// The IP addresses of the nameservers the appliance should use
 		//  and place in "/etc/systemd/resolved.conf".
 		"appliance_name_servers": &schema.Schema{
-			Type:     schema.TypeSet,
+			Type:     schema.TypeList,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
@@ -1295,7 +1295,7 @@ func resourceTrafficManagerObjectFieldAssignments(d *schema.ResourceData, object
 	setBool(&object.Appliance.Managevpcconf, d, "appliance_managevpcconf")
 
 	if _, ok := d.GetOk("appliance_name_servers"); ok {
-		setStringSet(&object.Appliance.NameServers, d, "appliance_name_servers")
+		setStringList(&object.Appliance.NameServers, d, "appliance_name_servers")
 	} else {
 		object.Appliance.NameServers = &[]string{}
 		d.Set("appliance_name_servers", []string(*object.Appliance.NameServers))


### PR DESCRIPTION
vtm_traffic_manager.appliance_name_servers should be TypeList not TypeSet

List would allow to control order of DNS servers in configuration